### PR TITLE
Fix lint scripts and run-profiles handling

### DIFF
--- a/Tests/scripts/test_error_handling.sh
+++ b/Tests/scripts/test_error_handling.sh
@@ -23,16 +23,16 @@ print_status() {
     local message=$2
     if [ "$status" = "PASS" ]; then
         echo -e "${GREEN}✅ $message${NC}"
-        ((PASSED_TESTS++))
+        ((PASSED_TESTS+=1))
     elif [ "$status" = "FAIL" ]; then
         echo -e "${RED}❌ $message${NC}"
-        ((FAILED_TESTS++))
+        ((FAILED_TESTS+=1))
     elif [ "$status" = "INFO" ]; then
         echo -e "${BLUE}ℹ️  $message${NC}"
     elif [ "$status" = "WARN" ]; then
         echo -e "${YELLOW}⚠️  $message${NC}"
     fi
-    ((TOTAL_TESTS++))
+    ((TOTAL_TESTS+=1))
 }
 
 # Function to create a divider of equal signs
@@ -314,9 +314,9 @@ test_frontend_errors() {
 
 # Function to print final summary
 print_summary() {
-    echo -e "\n${'='*60}"
-    echo -e "${BLUE}ERROR HANDLING TEST SUMMARY${NC}"
+    printf '\n'
     divider
+    echo -e "${BLUE}ERROR HANDLING TEST SUMMARY${NC}"
     
     echo "Total Tests: $TOTAL_TESTS"
     echo -e "${GREEN}Passed: $PASSED_TESTS${NC}"

--- a/docs/run-profiles.zsh
+++ b/docs/run-profiles.zsh
@@ -2,15 +2,16 @@
 # zsh /Users/rinikrishnan/resume-knowledge-base/docs/run-profiles.zsh
 
 
+# Get the repo root directory
+REPO_ROOT=$(git rev-parse --show-toplevel)
+
 # ----- Clears old files in the run-logs folder to start fresh -----
 echo "Clearing old files in the run-logs directory..."
-rm -f /Users/rinikrishnan/resume-knowledge-base/docs/run-logs/*
+rm -f "$REPO_ROOT/docs/run-logs/"*
 
 # ----- Continue with the rest of the script -----
 set -euo pipefail
 
-# Get the repo root directory
-REPO_ROOT=$(git rev-parse --show-toplevel)
 cd $REPO_ROOT
 
 # Define profiles and logs
@@ -48,7 +49,7 @@ echo "SUMMARY_FILE is set to: $SUMMARY_FILE"
 
 # Run the profile script generation...
 echo 'Running profile script generation...'
-zsh-script-gen > $GEN_LOG 2>&1
+zsh-script-gen > $GEN_LOG 2>&1 || true
 
 # Extract errors from the script generation log
 extract_errs() {
@@ -60,7 +61,7 @@ GEN_ERRS=$(extract_errs $GEN_LOG)
 
 # Run the validation script
 echo 'Running validation...'
-zsh-validation-run > $VAL_LOG 2>&1
+zsh-validation-run > $VAL_LOG 2>&1 || true
 
 # Extract errors from the validation log
 VAL_ERRS=$(extract_errs $VAL_LOG)

--- a/tools/linting/lint-backend
+++ b/tools/linting/lint-backend
@@ -325,9 +325,10 @@ run_shellcheck() {
 
 # Function to print summary
 print_summary() {
-    echo -e "\n${'='*60}"
+    printf '\n'
+    printf '=%.0s' {1..60}; echo
     echo -e "${BLUE}BACKEND LINTING SUMMARY${NC}"
-    echo ${'='*60}
+    printf '=%.0s' {1..60}; echo
     
     echo "Total Checks: $TOTAL_CHECKS"
     echo -e "${GREEN}Passed: $PASSED_CHECKS${NC}"
@@ -347,7 +348,7 @@ print_summary() {
 # Main execution
 main() {
     echo -e "${BLUE}🧹 Starting Backend Linting${NC}"
-    echo ${'='*60}
+    printf '=%.0s' {1..60}; echo
     
     # Install dependencies if needed
     install_dependencies

--- a/tools/linting/lint-frontend
+++ b/tools/linting/lint-frontend
@@ -317,9 +317,10 @@ validate_build_config() {
 
 # Function to print summary
 print_summary() {
-    echo -e "\n${'='*60}"
+    printf '\n'
+    printf '=%.0s' {1..60}; echo
     echo -e "${BLUE}FRONTEND LINTING SUMMARY${NC}"
-    echo ${'='*60}
+    printf '=%.0s' {1..60}; echo
     
     echo "Total Checks: $TOTAL_CHECKS"
     echo -e "${GREEN}Passed: $PASSED_CHECKS${NC}"
@@ -339,7 +340,7 @@ print_summary() {
 # Main execution
 main() {
     echo -e "${BLUE}🧹 Starting Frontend Linting${NC}"
-    echo ${'='*60}
+    printf '=%.0s' {1..60}; echo
     
     # Install dependencies if needed
     install_dependencies


### PR DESCRIPTION
## Summary
- fix bash string repetition in backend and frontend lint scripts
- improve error-handling script counters and summary
- make run-profiles.zsh use repo-relative paths and continue on errors

## Testing
- `python Tests/unit/test_error_scenarios.py`
- `tools/linting/lint-backend`
- `tools/linting/lint-frontend`
- `zsh docs/run-profiles.zsh`

------
https://chatgpt.com/codex/tasks/task_e_68a1694616508324b0f26232b6917f69