### PR TITLE
Fix lint-backend separator output

### DIFF
--- a/tools/linting/lint-backend
+++ b/tools/linting/lint-backend
@@ -347,8 +347,8 @@ print_summary() {
 # Main execution
 main() {
     echo -e "${BLUE}🧹 Starting Backend Linting${NC}"
-    echo ${'='*60}
-    
+    printf '=%.0s' {1..60}; echo
+
     # Install dependencies if needed
     install_dependencies
     


### PR DESCRIPTION
## Summary
- Replace invalid Python-style string expansion in `lint-backend` with portable `printf`.

## Testing
- `zsh docs/run-profiles.zsh` *(fails: API server not running, missing test scripts)*

------
https://chatgpt.com/codex/tasks/task_e_68a1694616508324b0f26232b6917f69