### PR TITLE
Fix lint scripts and run-profiles cleanup

### DIFF
--- a/docs/run-profiles.zsh
+++ b/docs/run-profiles.zsh
@@ -4,7 +4,8 @@
 
 # ----- Clears old files in the run-logs folder to start fresh -----
 echo "Clearing old files in the run-logs directory..."
-rm -f /Users/rinikrishnan/resume-knowledge-base/docs/run-logs/*
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+find "$SCRIPT_DIR/run-logs" -type f -delete 2>/dev/null || true
 
 # ----- Continue with the rest of the script -----
 set -euo pipefail

--- a/logs/2025/test-git-operations.json
+++ b/logs/2025/test-git-operations.json
@@ -1,0 +1,14 @@
+{
+  "date": "2025-08-16",
+  "title": "Git Operations Test",
+  "description": "Testing file creation and Git operations",
+  "tags": [
+    "Testing",
+    "Git"
+  ],
+  "impact_level": "Testing",
+  "visibility": [
+    "Internal"
+  ],
+  "resume_bullet": "Validated Git operations and file creation functionality"
+}

--- a/logs/git-test.json
+++ b/logs/git-test.json
@@ -1,0 +1,4 @@
+{
+  "test": "git operations",
+  "timestamp": "2025-08-17T06:01:17.154764"
+}

--- a/tools/linting/lint-backend
+++ b/tools/linting/lint-backend
@@ -17,6 +17,9 @@ TOTAL_CHECKS=0
 PASSED_CHECKS=0
 FAILED_CHECKS=0
 
+# Separator line
+SEPARATOR=$(printf '=%.0s' {1..60})
+
 # Function to print colored output
 print_status() {
     local status=$1
@@ -325,9 +328,9 @@ run_shellcheck() {
 
 # Function to print summary
 print_summary() {
-    echo -e "\n${'='*60}"
+    echo -e "\n${SEPARATOR}"
     echo -e "${BLUE}BACKEND LINTING SUMMARY${NC}"
-    echo ${'='*60}
+    echo "$SEPARATOR"
     
     echo "Total Checks: $TOTAL_CHECKS"
     echo -e "${GREEN}Passed: $PASSED_CHECKS${NC}"
@@ -347,7 +350,7 @@ print_summary() {
 # Main execution
 main() {
     echo -e "${BLUE}🧹 Starting Backend Linting${NC}"
-    echo ${'='*60}
+    echo "$SEPARATOR"
     
     # Install dependencies if needed
     install_dependencies

--- a/tools/linting/lint-design
+++ b/tools/linting/lint-design
@@ -18,6 +18,9 @@ PASSED_CHECKS=0
 FAILED_CHECKS=0
 VIOLATIONS=()
 
+# Separator line
+SEPARATOR=$(printf '=%.0s' {1..60})
+
 # Approved design system values
 APPROVED_COLORS=(
     "#f1f5f9" "#e2e8f0" "#cbd5e1" "#94a3b8" "#64748b" 
@@ -256,9 +259,9 @@ print_violations() {
 
 # Function to print summary
 print_summary() {
-    echo -e "\n${'='*60}"
+    echo -e "\n${SEPARATOR}"
     echo -e "${BLUE}DESIGN SYSTEM LINTING SUMMARY${NC}"
-    echo ${'='*60}
+    echo "$SEPARATOR"
     
     echo "Total Checks: $TOTAL_CHECKS"
     echo -e "${GREEN}Passed: $PASSED_CHECKS${NC}"
@@ -281,7 +284,7 @@ print_summary() {
 # Main execution
 main() {
     echo -e "${BLUE}🎨 Starting Design System Compliance Check${NC}"
-    echo ${'='*60}
+    echo "$SEPARATOR"
     
     # Run all design validation checks
     scan_frontend_files

--- a/tools/linting/lint-frontend
+++ b/tools/linting/lint-frontend
@@ -17,6 +17,9 @@ TOTAL_CHECKS=0
 PASSED_CHECKS=0
 FAILED_CHECKS=0
 
+# Separator line
+SEPARATOR=$(printf '=%.0s' {1..60})
+
 # Function to print colored output
 print_status() {
     local status=$1
@@ -317,9 +320,9 @@ validate_build_config() {
 
 # Function to print summary
 print_summary() {
-    echo -e "\n${'='*60}"
+    echo -e "\n${SEPARATOR}"
     echo -e "${BLUE}FRONTEND LINTING SUMMARY${NC}"
-    echo ${'='*60}
+    echo "$SEPARATOR"
     
     echo "Total Checks: $TOTAL_CHECKS"
     echo -e "${GREEN}Passed: $PASSED_CHECKS${NC}"
@@ -339,7 +342,7 @@ print_summary() {
 # Main execution
 main() {
     echo -e "${BLUE}🧹 Starting Frontend Linting${NC}"
-    echo ${'='*60}
+    echo "$SEPARATOR"
     
     # Install dependencies if needed
     install_dependencies


### PR DESCRIPTION
## Summary
- fix hardcoded path in run-profiles.zsh and safely clear logs
- replace bash-incompatible substitutions in lint scripts with portable separators

## Testing
- `python Tests/unit/test_api_endpoint.py` *(fails: connection refused)*
- `python Tests/unit/test_git_operations.py`
- `python Tests/unit/test_error_scenarios.py`
- `python Tests/integration/validate_backend.py`
- `bash Tests/scripts/test_error_handling.sh`
- `zsh docs/run-profiles.zsh` *(fails: see logs)*

------
https://chatgpt.com/codex/tasks/task_e_68a1694616508324b0f26232b6917f69